### PR TITLE
Fix switch statement

### DIFF
--- a/xmlseclibs.php
+++ b/xmlseclibs.php
@@ -292,6 +292,7 @@ class XMLSecurityKey {
                         break;
                     }
                 }
+                throw new Exception('Certificate "type" (private/public) must be passed via parameters');
             case (XMLSecurityKey::RSA_SHA512):
                 $this->cryptParams['library'] = 'openssl';
                 $this->cryptParams['method'] = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512';
@@ -303,6 +304,7 @@ class XMLSecurityKey {
                         break;
                     }
                 }
+                throw new Exception('Certificate "type" (private/public) must be passed via parameters');
             case (XMLSecurityKey::HMAC_SHA1):
 			    $this->cryptParams['library'] = $type;
                 $this->cryptParams['method'] = 'http://www.w3.org/2000/09/xmldsig#hmac-sha1';


### PR DESCRIPTION
I believe this was my fault when submitting the original patch to implement support for SHA2-family. In any case, here's a fix for a couple of cases in a switch that should end with an exception but currently do not.