### PR TITLE
Fixed newlines for tests

### DIFF
--- a/tests/sign-c14-comments.phpt
+++ b/tests/sign-c14-comments.phpt
@@ -39,9 +39,9 @@ $doc->save(dirname(__FILE__) . '/sign-c14-comments.xml');
 $sign_output = file_get_contents(dirname(__FILE__) . '/sign-c14-comments.xml');
 $sign_output_def = file_get_contents(dirname(__FILE__) . '/sign-c14-comments.res');
 if ($sign_output != $sign_output_def) {
-    echo "NOT THE SAME";
+    echo "NOT THE SAME\n";
 }
-echo "DONE";
+echo "DONE\n";
 ?>
 --EXPECTF--
 DONE

--- a/tests/thumbprint.phpt
+++ b/tests/thumbprint.phpt
@@ -9,7 +9,7 @@ $siteKey->loadKey(dirname(__FILE__) . '/mycert.pem', TRUE, TRUE);
 
 $thumbprint = $siteKey->getX509Thumbprint();
 echo $thumbprint."\n";
-echo base64_encode($thumbprint);
+echo base64_encode($thumbprint)."\n";
 ?>
 --EXPECTF--
 8b600d9155e8e8dfa3c10998f736be086e83ef3b

--- a/tests/xml-sign-sha256-rsa-sha256.phpt
+++ b/tests/xml-sign-sha256-rsa-sha256.phpt
@@ -37,9 +37,9 @@ $doc->save(dirname(__FILE__) . '/sign-sha256-rsa-sha256-test.xml');
 $sign_output = file_get_contents(dirname(__FILE__) . '/sign-sha256-rsa-sha256-test.xml');
 $sign_output_def = file_get_contents(dirname(__FILE__) . '/sign-sha256-rsa-sha256-test.res');
 if ($sign_output != $sign_output_def) {
-	echo "NOT THE SAME";
+	echo "NOT THE SAME\n";
 }
-echo "DONE";
+echo "DONE\n";
 ?>
 --EXPECTF--
 DONE

--- a/tests/xml-sign-subject.phpt
+++ b/tests/xml-sign-subject.phpt
@@ -35,9 +35,9 @@ $doc->save(dirname(__FILE__) . '/sign-subject.xml');
 $sign_output = file_get_contents(dirname(__FILE__) . '/sign-subject.xml');
 $sign_output_def = file_get_contents(dirname(__FILE__) . '/sign-subject.res');
 if ($sign_output != $sign_output_def) {
-	echo "NOT THE SAME";
+	echo "NOT THE SAME\n";
 }
-echo "DONE";
+echo "DONE\n";
 ?>
 --EXPECTF--
 DONE

--- a/tests/xml-sign.phpt
+++ b/tests/xml-sign.phpt
@@ -35,9 +35,9 @@ $doc->save(dirname(__FILE__) . '/sign-basic-test.xml');
 $sign_output = file_get_contents(dirname(__FILE__) . '/sign-basic-test.xml');
 $sign_output_def = file_get_contents(dirname(__FILE__) . '/sign-basic-test.res');
 if ($sign_output != $sign_output_def) {
-	echo "NOT THE SAME";
+	echo "NOT THE SAME\n";
 }
-echo "DONE";
+echo "DONE\n";
 ?>
 --EXPECTF--
 DONE

--- a/tests/xmlsec-decrypt-content.phpt
+++ b/tests/xmlsec-decrypt-content.phpt
@@ -90,4 +90,3 @@ foreach ($arTests AS $testName=>$testFile) {
 --EXPECTF--
 AOESP_SHA1: Passed
 AOESP_SHA1_CONTENT: Passed
-

--- a/tests/xmlsec-encrypt-content.phpt
+++ b/tests/xmlsec-encrypt-content.phpt
@@ -27,7 +27,7 @@ $encNode = $enc->encryptNode($objKey);
 $dom->save(dirname(__FILE__) . '/oaep_sha1.xml');
 
 $root = $dom->documentElement;
-echo $root->localName;
+echo $root->localName."\n";
 
 unlink(dirname(__FILE__) . '/oaep_sha1.xml');
 

--- a/tests/xmlsec-encrypt.phpt
+++ b/tests/xmlsec-encrypt.phpt
@@ -27,7 +27,7 @@ $encNode = $enc->encryptNode($objKey);
 $dom->save(dirname(__FILE__) . '/oaep_sha1.xml');
 
 $root = $dom->documentElement;
-echo $root->localName;
+echo $root->localName."\n";
 
 unlink(dirname(__FILE__) . '/oaep_sha1.xml');
 


### PR DESCRIPTION
This PR fixes newlines that are generated during the tests. 

They are mostly inconsistent at the moment, although the program running the tests may accept invalid newlines. 