### PR TITLE
Added basic usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,42 @@ xmlseclibs is being used in many different software.
 * [SimpleSAMLPHP](https://github.com/simplesamlphp/simplesamlphp)
 * [LightSAML](https://github.com/aerialship/lightsaml)
 
+## Basic usage
 
+The example below shows basic usage of xmlseclibs, with a SHA-256 signature.
+
+```php
+// Load the XML to be signed
+$doc = new DOMDocument();
+$doc->load('./path/to/file/tobesigned.xml');
+
+// Create a new Security object 
+$objDSig = new XMLSecurityDSig();
+// Use the c14n exclusive canonicalization
+$objDSig->setCanonicalMethod(XMLSecurityDSig::EXC_C14N);
+// Sign using SHA-256
+$objDSig->addReference($doc, XMLSecurityDSig::SHA256, array('http://www.w3.org/2000/09/xmldsig#enveloped-signature'));
+
+// Create a new (private) Security key
+$objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type'=>'private'));
+// Load the private key
+$objKey->loadKey('./path/to/privatekey.pem', TRUE);
+/* 
+If key has a passphrase, set it using 
+$objKey->passphrase = '<passphrase>';
+*/
+
+// Sign the XML file
+$objDSig->sign($objKey);
+
+// Add the associated public key to the signature
+$objDSig->add509Cert(file_get_contents('./path/to/file/mycert.pem'));
+
+// Append the signature to the XML
+$objDSig->appendSignature($doc->documentElement);
+// Save the signed XML
+$doc->save('./path/to/signed.xml');
+```
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ $objDSig = new XMLSecurityDSig();
 // Use the c14n exclusive canonicalization
 $objDSig->setCanonicalMethod(XMLSecurityDSig::EXC_C14N);
 // Sign using SHA-256
-$objDSig->addReference($doc, XMLSecurityDSig::SHA256, array('http://www.w3.org/2000/09/xmldsig#enveloped-signature'));
+$objDSig->addReference(
+    $doc, 
+    XMLSecurityDSig::SHA256, 
+    array('http://www.w3.org/2000/09/xmldsig#enveloped-signature')
+);
 
 // Create a new (private) Security key
 $objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type'=>'private'));


### PR DESCRIPTION
I've found some requests on the internet asking for a basic usage scenario or documentation in general about the `xmlseclibs` library.

I added a basic usage scenario, taken from the `xml-sign-sha256-rsa-sha256.phpt` test which should help people start using the library.