### PR TITLE
Remove alternatives for hash().

### DIFF
--- a/xmlseclibs.php
+++ b/xmlseclibs.php
@@ -706,18 +706,9 @@ class XMLSecurityDSig {
                 $alg = 'ripemd160';
                 break;
             default:
-                throw new Exception("Cannot validate digest: Unsupported Algorith <$digestAlgorithm>");
+                throw new Exception("Cannot validate digest: Unsupported Algorithm <$digestAlgorithm>");
         }
-        if (function_exists('hash')) {
-            return base64_encode(hash($alg, $data, TRUE));
-        } elseif (function_exists('mhash')) {
-            $alg = "MHASH_" . strtoupper($alg);
-            return base64_encode(mhash(constant($alg), $data));
-        } elseif ($alg === 'sha1') {
-            return base64_encode(sha1($data, TRUE));
-        } else {
-            throw new Exception('xmlseclibs is unable to calculate a digest. Maybe you need the mhash library?');
-        }
+        return base64_encode(hash($alg, $data, TRUE));
     }
 
     public function validateDigest($refNode, $data) {


### PR DESCRIPTION
This makes the code quite a bit more straightforward and hash() is part of PHP core since 5.1.2 and we require 5.2 as a minimum.

Functions from the hash module (`hash_hmac`) are used without this check in other places in the code.