### PR TITLE
Optional certificate and issuer as array

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -990,12 +990,16 @@ class XMLSecurityDSig
 
         $issuerSerial = false;
         $subjectName = false;
+        $issuerCertificate = true;
         if (is_array($options)) {
             if (! empty($options['issuerSerial'])) {
                 $issuerSerial = true;
             }
             if (! empty($options['subjectName'])) {
                 $subjectName = true;
+            }
+            if (isset($options['issuerCertificate']) && $options['issuerCertificate']===false) {
+                $issuerCertificate = false;
             }
         }
 
@@ -1026,7 +1030,13 @@ class XMLSecurityDSig
                         if (is_array($certData['issuer'])) {
                             $parts = array();
                             foreach ($certData['issuer'] AS $key => $value) {
-                                array_unshift($parts, "$key=$value");
+                                if (is_array($value)) {
+                                    foreach ($value as $valueElement) {
+                                        array_unshift($parts, "$key=$valueElement");
+                                    }
+                                } else {
+                                    array_unshift($parts, "$key=$value");
+                                }
                             }
                             $issuerName = implode(',', $parts);
                         } else {
@@ -1044,8 +1054,10 @@ class XMLSecurityDSig
                 }
 
             }
-            $x509CertNode = $baseDoc->createElementNS(self::XMLDSIGNS, $dsig_pfx.'X509Certificate', $X509Cert);
-            $x509DataNode->appendChild($x509CertNode);
+            if ($issuerCertificate) {
+                $x509CertNode = $baseDoc->createElementNS(self::XMLDSIGNS, $dsig_pfx.'X509Certificate', $X509Cert);
+                $x509DataNode->appendChild($x509CertNode);
+            }
         }
     }
 


### PR DESCRIPTION
(1) Similar to [previous commit](https://github.com/robrichards/xmlseclibs/commit/4f9818d779b4757632c2f86622c38844b192c9bd) -Issuer can be also array
(2) Sometimes certificate may not be necessary. eg when it is already stored on the server that verifies signature throuh certificate serial
