### PR TITLE
HHVM signing node with ID attribute w/out namespace regenerates ID

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -629,7 +629,7 @@ class XMLSecurityDSig
         if (! $node instanceof DOMDocument) {
             $uri = null;
             if (! $overwrite_id) {
-                $uri = $node->getAttributeNS($prefix_ns, $id_name);
+                $uri = $prefix_ns ? $node->getAttributeNS($prefix_ns, $id_name) : $node->getAttribute($id_name);
             }
             if (empty($uri)) {
                 $uri = self::generateGUID();

--- a/tests/sign-hhvm-id-wout-ns-regenerated.phpt
+++ b/tests/sign-hhvm-id-wout-ns-regenerated.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Signing HHVM ID w/out ns regenerated
+--DESCRIPTION--
+Signing on HHVM a node which id attribute does not have namespace prefix, prevent regeneratation of its ID
+--FILE--
+<?php
+
+require(dirname(__FILE__) . '/../xmlseclibs.php');
+
+use RobRichards\XMLSecLibs\XMLSecurityDSig;
+use RobRichards\XMLSecLibs\XMLSecurityKey;
+
+$doc = new \DOMDocument();
+$doc->load(__DIR__.'/sign-hhvm-id-wout-ns-regenerated.xml');
+
+$objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA1, array('type'=>'private'));
+$objKey->loadKey(dirname(__FILE__) . '/privkey.pem', TRUE);
+
+/** @var \DOMElement $assertion */
+$assertion = $doc->getElementsByTagName('Assertion')->item(0);
+
+$objXMLSecDSig = new XMLSecurityDSig();
+$objXMLSecDSig->setCanonicalMethod(XMLSecurityDSig::EXC_C14N);
+$objXMLSecDSig->addReferenceList(
+    array($assertion),
+    XMLSecurityDSig::SHA1,
+    array('http://www.w3.org/2000/09/xmldsig#enveloped-signature', XMLSecurityDSig::EXC_C14N),
+    array('id_name' => 'ID', 'overwrite' => false)
+);
+
+print $assertion->getAttribute('ID')."\n";
+?>
+--EXPECTF--
+assertion-id

--- a/tests/sign-hhvm-id-wout-ns-regenerated.xml
+++ b/tests/sign-hhvm-id-wout-ns-regenerated.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="response-id" InResponseTo="in-reponse-to" Version="2.0" IssueInstant="2013-10-27T11:55:37Z" Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified" Destination="http://destination.com">
+    <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">the-issuer</saml:Issuer>
+    <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="assertion-id" Version="2.0" IssueInstant="2013-10-27T11:55:37Z">
+        <Issuer>assertion-issuer</Issuer>
+        <Subject>
+            <NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">assertion-name-id</NameID>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <SubjectConfirmationData InResponseTo="assertion-in-response-to" NotOnOrAfter="2013-10-27T12:00:37Z" Recipient="http://recipient.com"/>
+            </SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="2013-10-27T11:55:37Z" NotOnOrAfter="2013-10-27T12:55:37Z">
+            <AudienceRestriction>
+                <Audience>http://audience.com</Audience>
+            </AudienceRestriction>
+        </Conditions>
+        <AttributeStatement>
+            <Attribute Name="http://schemas.xmlsoap.org/claims/CommonName" FriendlyName="Common Name">
+                <AttributeValue>cn value</AttributeValue>
+            </Attribute>
+            <Attribute Name="http://schemas.xmlsoap.org/claims/Group" FriendlyName="Group">
+                <AttributeValue>group one</AttributeValue>
+                <AttributeValue>group two</AttributeValue>
+            </Attribute>
+        </AttributeStatement>
+        <AuthnStatement AuthnInstant="2013-10-27T11:55:36Z" SessionIndex="session-index">
+            <AuthnContext>
+                <AuthnContextClassRef>authn-context-class-ref</AuthnContextClassRef>
+            </AuthnContext>
+        </AuthnStatement>
+    </Assertion>
+</samlp:Response>


### PR DESCRIPTION
Fix for issue #88 

Since hhvm tests are failing on travis I were able to test it only manually on HHVM 3.10.1 ubuntu 14.04

Before fix
```
ubuntu@ubuntu-amd64:/var/www/html/xmlseclibs/tests$ hhvm sign-hhvm-id-wout-ns-regenerated.php
--TEST--
Signing HHVM ID w/out ns regenerated
--DESCRIPTION--
Signing on HHVM a node which id attribute does not have namespace prefix, prevent regeneratation of its ID
--FILE--
pfx5d8385e0-d44e-f7e2-aab2-511f94a163d6
--EXPECTF--
assertion-id
```

And after fix

```
ubuntu@ubuntu-amd64:/var/www/html/xmlseclibs/tests$ hhvm sign-hhvm-id-wout-ns-regenerated.php
--TEST--
Signing HHVM ID w/out ns regenerated
--DESCRIPTION--
Signing on HHVM a node which id attribute does not have namespace prefix, prevent regeneratation of its ID
--FILE--
pfx5d8385e0-d44e-f7e2-aab2-511f94a163d6
--EXPECTF--
assertion-id
```