### PR TITLE
Add an autoloader providing backwards-compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   "autoload": {
     "psr-4": {
       "RobRichards\\XMLSecLibs\\": "src"
-    }
+    },
+    "files": ["src/_autoload.php"]
   },
   "require": {
     "php": ">= 5.3"

--- a/src/_autoload.php
+++ b/src/_autoload.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Temporary autoloader to ensure compatibility with old, non-PSR-2 compliant classes.
+ *
+ * @author Jaime Pérez Crespo <jaime.perez@uninett.no>
+ */
+
+/**
+ * Autoload function that looks for classes migrated to PSR-2.
+ *
+ * @param string $className Name of the class.
+ */
+function xmlseclibs_autoload($className)
+{
+    // handle the new namespaces
+    $newClasses = array(
+        'XMLSecEnc' => '\\RobRichards\\XMLSecLibs\\XMLSecEnc',
+        'XMLSecurityDSig' => '\\RobRichards\\XMLSecLibs\\XMLSecurityDSig',
+        'XMLSecurityKey' => '\\RobRichards\\XMLSecLibs\\XMLSecurityKey',
+
+    );
+
+    $file = dirname(__FILE__).'/'.$className.'.php';
+    if (file_exists($file)) {
+        require_once($file);
+        class_alias($newClasses[$className], $className);
+        // maybe log a warning here?
+    }
+
+}
+
+spl_autoload_register('xmlseclibs_autoload');


### PR DESCRIPTION
This PR adds a file that implements and registers an autoloader. This autoloader recognizes the old class names:

* `XMLSecEnc`
* `XMLSecurityDSig`
* `XMLSecurityKey`

and translates them into their appropriate new names including namespaces (`\RobRichards\XMLSecLibs\*`), creating aliases for every class when it is loaded. For those already using namespaces, this autoloader will have no effect and won't be even run.

This allows users of the library to start using the `2.*` branch and start migrating their own code to the new classes using namespaces, at their own pace. We will use it in `simplesamlphp/saml2` and `simplesamlphp/simplesamlphp` for that purpose, for instance. For small code bases it might be ok to just bump the version required in `composer.json` at the same time you are making the actual changes, but for large code bases it's much easier if the migration can be split in several, smaller commits.

I would definitely consider this as temporary, though. I would set a date in the future (say one year from now, for example), and remove the autoloader then. It's time enough for people to migrate, and backwards-compatibility cannot be kept forever, or you risk people ignoring changes and continuing business as usual.

Of course we would need a new stable release of XMLSecLibs with this, if this gets merged.

Thanks in advance!