### PR TITLE
Fix bug in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ $objDSig->addReference(
 
 // Create a new (private) Security key
 $objKey = new XMLSecurityKey(XMLSecurityKey::RSA_SHA256, array('type'=>'private'));
-// Load the private key
-$objKey->loadKey('./path/to/privatekey.pem', TRUE);
-/* 
-If key has a passphrase, set it using 
+/*
+If key has a passphrase, set it using
 $objKey->passphrase = '<passphrase>';
 */
+// Load the private key
+$objKey->loadKey('./path/to/privatekey.pem', TRUE);
 
 // Sign the XML file
 $objDSig->sign($objKey);


### PR DESCRIPTION
When the key file is locked with a passphrase, it must be set FIRST,
before the key is loaded, otherwise it will fail to load, giving this
warning:

    openssl_sign(): supplied key param cannot be coerced into a private key