### PR TITLE
Use an xpath query which ignores namespaces.

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -489,7 +489,7 @@ class XMLSecurityDSig
                             $xPath->registerNamespace($nspf, $ns);
                         }
                     }
-                    $iDlist = '@Id="'.$identifier.'"';
+                    $iDlist = "@*[local-name() = 'Id'] = '$identifier'";
                     if (is_array($this->idKeys)) {
                         foreach ($this->idKeys AS $idKey) {
                             $iDlist .= " or @$idKey='$identifier'";


### PR DESCRIPTION
The response I get using a specific service has a "wsu" prefix (http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd) which looks likes like this: <soapenv:Body xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" wsu:Id="Id-1144197523">

This patch makes it so it ignores all prefixes and just checks by if the name is Id.