### PR TITLE
 Document verify return value risk and fix tests

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -774,6 +774,17 @@ class XMLSecurityDSig
     }
 
     /**
+     * Returns:
+     *  Bool when verifying HMAC_SHA1;
+     *  Int otherwise, with following meanings:
+     *    1 on succesful signature verification,
+     *    0 when signature verification failed,
+     *   -1 if an error occurred during processing.
+     *
+     * NOTE: be very careful when checking the int return value, because in
+     * PHP, -1 will be cast to True when in boolean context. Always check the
+     * return value in a strictly typed way, e.g. "$obj->verify(...) === 1".
+     *
      * @param XMLSecurityKey $objKey
      * @return bool|int
      * @throws Exception

--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -505,6 +505,15 @@ class XMLSecurityKey
     /**
      * Verifies the given data (string) belonging to the given signature using the openssl-extension
      *
+     * Returns:
+     *  1 on succesful signature verification,
+     *  0 when signature verification failed,
+     *  -1 if an error occurred during processing.
+     *
+     * NOTE: be very careful when checking the return value, because in PHP,
+     * -1 will be cast to True when in boolean context. So always check the
+     * return value in a strictly typed way, e.g. "$obj->verify(...) === 1".
+     *
      * @param string $data
      * @param string $signature
      * @return int

--- a/tests/extract-win-cert.phpt
+++ b/tests/extract-win-cert.phpt
@@ -34,7 +34,7 @@ foreach ($arTests AS $testName=>$testFile) {
 	if ($testName == 'SIGN_TEST') {
 		$objKey->loadKey(dirname(__FILE__) . '/mycert.pem', TRUE);
 		print $testName.": ";
-		if ($objXMLSecDSig->verify($objKey)) {
+		if ($objXMLSecDSig->verify($objKey) === 1) {
 			print "Signature validated!";
 		} else {
 			print "Failure!!!!!!!!";

--- a/tests/xmlsec-verify-formatted.phpt
+++ b/tests/xmlsec-verify-formatted.phpt
@@ -40,7 +40,7 @@ foreach ($arTests AS $testName=>$testFile) {
 	}
 	
 	print $testName.": ";
-	if ($objXMLSecDSig->verify($objKey)) {
+	if ($objXMLSecDSig->verify($objKey) === 1) {
 		print "Signature validated!";
 	} else {
 		print "Failure!!!!!!!!";

--- a/tests/xmlsec-verify-rsa-sha256.phpt
+++ b/tests/xmlsec-verify-rsa-sha256.phpt
@@ -42,7 +42,7 @@ foreach ($arTests AS $testName=>$testFile) {
 	}
 
 	print $testName.": ";
-	if ($objXMLSecDSig->verify($objKey)) {
+	if ($objXMLSecDSig->verify($objKey) === 1) {
 		print "Signature validated!";
 	} else {
 		print "Failure!!!!!!!!";

--- a/tests/xmlsec-verify.phpt
+++ b/tests/xmlsec-verify.phpt
@@ -40,7 +40,7 @@ foreach ($arTests AS $testName=>$testFile) {
 	}
 
 	print $testName.": ";
-	if ($objXMLSecDSig->verify($objKey)) {
+	if ($objXMLSecDSig->verify($objKey) === 1) {
 		print "Signature validated!";
 	} else {
 		print "Failure!!!!!!!!";


### PR DESCRIPTION
The verify() method has a risky return values -1, 0 and 1. PHP may cast -1 in a boolean context to true, making any error during signature processing evaluate to true. So this return value should be checked carefully in applications that use the method. Document this in the comment blocks. Also update the tests to invoke it 'the right way', to avoid the wrong construct being copied by someone to live code.