### PR TITLE
Travis: add PHP 7.1, move hhvm to allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
       env:
         - EXECUTE_COVERAGE=true
     - php: 7
+    - php: 7.1
+  allow_failures:
     - php: hhvm
     
 script:


### PR DESCRIPTION
Composer installs a version of phpunit that is not compatible with the HHVM version that Travis supports. That can be worked around with lots of hoop jumping, but that seems out of scope for xmlseclibs. Just allow hhvm to fail until Travis/HHVM supply a workable combo out of the box. It is more important for xmlseclibs that there's a reliable Travis result for the mainstream PHP versions.