### PR TITLE
Re-add PHP 5.4 and 5.5 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: php
 matrix:
   fast_finish: true
   include:
+    - php: 5.4
+    - php: 5.5
     - php: 5.6
       env:
         - EXECUTE_COVERAGE=true


### PR DESCRIPTION
This is to show that the testsuite passes just fine with these versions.