### PR TITLE
Append signature after a specific node

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -886,11 +886,13 @@ class XMLSecurityDSig
     /**
      * @param DOMNode $parentNode
      * @param bool $insertBefore
+	 * @param integer $insertBefore
      * @return DOMNode
      */
-    public function appendSignature($parentNode, $insertBefore = false)
+    public function appendSignature($parentNode, $insertBefore = false, $beforeElementPosition = 0)
     {
         $beforeNode = $insertBefore ? $parentNode->firstChild : null;
+		$beforeNode = $beforeElementPosition > 0 ? $parentNode->childNodes[$beforeElementPosition] : $beforeNode;
         return $this->insertSignature($parentNode, $beforeNode);
     }
 

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -886,13 +886,13 @@ class XMLSecurityDSig
     /**
      * @param DOMNode $parentNode
      * @param bool $insertBefore
-	 * @param integer $insertBefore
+     * @param integer $insertBefore
      * @return DOMNode
      */
     public function appendSignature($parentNode, $insertBefore = false, $beforeElementPosition = 0)
     {
         $beforeNode = $insertBefore ? $parentNode->firstChild : null;
-		$beforeNode = $beforeElementPosition > 0 ? $parentNode->childNodes[$beforeElementPosition] : $beforeNode;
+        $beforeNode = $beforeElementPosition > 0 ? $parentNode->childNodes[$beforeElementPosition] : $beforeNode;
         return $this->insertSignature($parentNode, $beforeNode);
     }
 


### PR DESCRIPTION
Hello,

To be compliant with urn:oasis:names:tc:SAML:2.0:protocol in a RequestedAuthnContext, the signature have to be append just after the Issuer node.

I need the possibility to define a position in function appendSignature.

Have a good day,

Sébastien