### PR TITLE
Restore support for PHP >= 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: php
 matrix:
   fast_finish: true
   include:
+    - php: 5.4
+    - php: 5.5
     - php: 5.6
       env:
         - EXECUTE_COVERAGE=true

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     }
   },
   "require": {
-    "php": ">= 5.6"
+    "php": ">= 5.4"
    },
   "suggest": {
     "ext-openssl": "OpenSSL extension"


### PR DESCRIPTION
As discussed in robrichards/xmlseclibs#123, support for PHP >= 5.4 should be restored after being removed for the latest 3.0 version that finally skips the _mcrypt_ dependency.