### PR TITLE
Fixed missing () in function call

### DIFF
--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -478,7 +478,7 @@ class XMLSecurityKey
     private function decryptPrivate($data)
     {
         if (! openssl_private_decrypt($data, $decrypted, $this->key, $this->cryptParams['padding'])) {
-            throw new Exception('Failure decrypting Data (openssl private) - ' . openssl_error_string);
+            throw new Exception('Failure decrypting Data (openssl private) - ' . openssl_error_string());
         }
         return $decrypted;
     }


### PR DESCRIPTION
The error handling the "decryptPrivate()", was wrongly using the function name without the ().
This caused an PHP notice: Notice: Use of undefined constant openssl_error_string
Aswell as not producing the expected result.