### PR TITLE
Add option to use template excluding whitespace

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -111,7 +111,6 @@ class XMLSecurityDSig
     public function __construct($prefix='ds', $options=null)
     {
         $template = (!empty($options['excludeWhitespace']) && $options['excludeWhitespace'] === true) ? self::BASE_TEMPLATE_NO_WHITESPACE : self::BASE_TEMPLATE;
-
         if (! empty($prefix)) {
             $this->prefix = $prefix.':';
             $search = array("<S", "</S", "xmlns=");

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -110,7 +110,7 @@ class XMLSecurityDSig
      */
     public function __construct($prefix='ds', $options=null)
     {
-        $template = (!empty($options['excludeWhiteSpace']) && $options['excludeWhiteSpace'] === true) ? self::BASE_TEMPLATE_NO_WHITESPACE : self::BASE_TEMPLATE;
+        $template = (!empty($options['excludeWhitespace']) && $options['excludeWhitespace'] === true) ? self::BASE_TEMPLATE_NO_WHITESPACE : self::BASE_TEMPLATE;
 
         if (! empty($prefix)) {
             $this->prefix = $prefix.':';

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -73,6 +73,8 @@ class XMLSecurityDSig
   </SignedInfo>
 </Signature>';
 
+    const BASE_TEMPLATE_NO_WHITESPACE = '<Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><SignatureMethod /></SignedInfo></Signature>';
+
     /** @var DOMElement|null */
     public $sigNode = null;
 
@@ -106,9 +108,10 @@ class XMLSecurityDSig
     /**
      * @param string $prefix
      */
-    public function __construct($prefix='ds')
+    public function __construct($prefix='ds', $options=null)
     {
-        $template = self::BASE_TEMPLATE;
+        $template = (!empty($options['excludeWhiteSpace']) && $options['excludeWhiteSpace'] === true) ? self::BASE_TEMPLATE_NO_WHITESPACE : self::BASE_TEMPLATE;
+
         if (! empty($prefix)) {
             $this->prefix = $prefix.':';
             $search = array("<S", "</S", "xmlns=");


### PR DESCRIPTION
As discussed in #77, this PR adds an optional configuration flag (`excludeWhiteSpace`) which ensures that the signature validates in .NET.

Feel free to amend the naming/implementation (e.g., you may not want this in the constructor) as you see fit, but it would be great to see something like this included in the library as I could find no other way to ensure my signatures can be validated in .NET.

I wasn't so sure about the coding style - sometimes, I saw argument assignments with spaces and sometimes without.  Hence, I just went with whatever I saw the most often.

Cheers,
JD