### PR TITLE
Move ext-openssl from suggestion to requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,7 @@
     }
   },
   "require": {
-    "php": ">= 5.4"
-   },
-  "suggest": {
-    "ext-openssl": "OpenSSL extension"
+    "php": ">= 5.4",
+    "ext-openssl": "*"
   }
 }


### PR DESCRIPTION
As openssl ext. is a hard dependency it should be defined as required in composer.json