### PR TITLE
Remove call to file_get_contents() that doesn't even work

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -500,8 +500,6 @@ class XMLSecurityDSig
                 } else {
                     $dataObject = $refNode->ownerDocument;
                 }
-            } else {
-                $dataObject = file_get_contents($arUrl);
             }
         } else {
             /* This reference identifies the root node with an empty URI. This should


### PR DESCRIPTION
This will never work since `$arUrl` will either be an array or `false`, as returned by the previous call to `parse_url()`. Since it has never worked, it is obviously something we don't need.

Should we choose to fix the bug instead of removing the line, we could open for all kinds of issues (denial of service, local file inclusion, remote file inclusion, etc), so fixing it is much more complicated than just changing the variable passed to `file_get_contents()`.