### PR TITLE
Use strict comparison operator to compare digest values

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -366,7 +366,7 @@ class XMLSecurityDSig
         $digValue = $this->calculateDigest($digestAlgorithm, $data, false);
         $query = 'string(./secdsig:DigestValue)';
         $digestValue = $xpath->evaluate($query, $refNode);
-        return ($digValue == base64_decode($digestValue));
+        return ($digValue === base64_decode($digestValue));
     }
 
     /**


### PR DESCRIPTION
The `==` comparison operator will compare loosely, casting both operands to integer if possible. This means if the actual digest and the one being validated both are strings that start with `0e` and continue with just numbers, the comparison will evaluate to `true`. E.g.:

```
php > var_dump("0e321" == "0e123456");
bool(true)
```