### PR TITLE
Remove unused recursive call

### DIFF
--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -732,7 +732,6 @@ class XMLSecurityKey
         }
         $objKey->isEncrypted = true;
         $objKey->encryptedCtx = $objenc;
-        XMLSecEnc::staticLocateKeyInfo($objKey, $element);
         return $objKey;
     }
 


### PR DESCRIPTION
When loading an EncryptedKey element, we call XMLSecEnc::staticLocateKeyInfo() to see if there's another KeyInfo element inside. This could happen when we have more than one level of key encryption. However, the static method does not modify the DOM or the key passed as parameters, it returns the key (or a new one). Given that the result of the call is never assigned to $objKey, this has never actually worked. It makes sense, since the most common escenario is data encrypted with a random symmetric key, and then that session key being sent alongside the cipherdata, in turn encrypted with the public key of the recipient.

We could fix this instead of just removing the line. However, given that it wasn't working, indicates there's no use for it. Fixing it on the other hand would require quite a lot of logic to limit the amount of recursion allowed.