### PR TITLE
Filter input for its use in XPath expressions

### DIFF
--- a/src/Utils/XPath.php
+++ b/src/Utils/XPath.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace RobRichards\XMLSecLibs\Utils;
+
+class XPath
+{
+    const ALPHANUMERIC = 0;
+    const NUMERIC = 1;
+    const LETTERS = 2;
+    const EXTENDED_ALPHANUMERIC = 3;
+
+    private static $regex = [
+        self::ALPHANUMERIC => '#[^\w\d]#',
+        self::NUMERIC => '#[^\d]#',
+        self::LETTERS => '#[^\w]#',
+        self::EXTENDED_ALPHANUMERIC => '#[^\w\d\s-_]#'
+    ];
+
+
+    /**
+     * Filter a string for save inclusion in an XPath query.
+     *
+     * @param string $input The query parameter to filter.
+     * @param int $allow The character set that we should allow.
+     *
+     * @return string The input filtered with only allowed characters.
+     */
+    public static function filter($input, $allow = self::EXTENDED_ALPHANUMERIC)
+    {
+        return preg_replace(self::$regex[$allow], '', $input);
+    }
+}

--- a/src/Utils/XPath.php
+++ b/src/Utils/XPath.php
@@ -13,7 +13,7 @@ class XPath
         self::ALPHANUMERIC => '#[^\w\d]#',
         self::NUMERIC => '#[^\d]#',
         self::LETTERS => '#[^\w]#',
-        self::EXTENDED_ALPHANUMERIC => '#[^\w\d\s-_]#'
+        self::EXTENDED_ALPHANUMERIC => '/[^\w\d\s-_:]/'
     ];
 
 

--- a/src/Utils/XPath.php
+++ b/src/Utils/XPath.php
@@ -4,29 +4,41 @@ namespace RobRichards\XMLSecLibs\Utils;
 
 class XPath
 {
-    const ALPHANUMERIC = 0;
-    const NUMERIC = 1;
-    const LETTERS = 2;
-    const EXTENDED_ALPHANUMERIC = 3;
+    const ALPHANUMERIC = '[^\w\d]';
+    const NUMERIC = '[^\d]';
+    const LETTERS = '[^\w]';
+    const EXTENDED_ALPHANUMERIC = '[^\w\d\s-_:\.]';
 
-    private static $regex = [
-        self::ALPHANUMERIC => '#[^\w\d]#',
-        self::NUMERIC => '#[^\d]#',
-        self::LETTERS => '#[^\w]#',
-        self::EXTENDED_ALPHANUMERIC => '/[^\w\d\s-_:]/'
-    ];
+    const SINGLE_QUOTE = '\'';
+    const DOUBLE_QUOTE = '"';
+    const ALL_QUOTES = '[\'"]';
 
 
     /**
-     * Filter a string for save inclusion in an XPath query.
+     * Filter an attribute value for save inclusion in an XPath query.
      *
-     * @param string $input The query parameter to filter.
-     * @param int $allow The character set that we should allow.
+     * @param string $value The value to filter.
+     * @param string $quotes The quotes used to delimit the value in the XPath query.
      *
-     * @return string The input filtered with only allowed characters.
+     * @return string The filtered attribute value.
      */
-    public static function filter($input, $allow = self::EXTENDED_ALPHANUMERIC)
+    public static function filterAttrValue($value, $quotes = self::ALL_QUOTES)
     {
-        return preg_replace(self::$regex[$allow], '', $input);
+        return preg_replace('#'.$quotes.'#', '', $value);
+    }
+
+
+    /**
+     * Filter an attribute name for save inclusion in an XPath query.
+     *
+     * @param string $name The attribute name to filter.
+     * @param mixed $allow The set of characters to allow. Can be one of the constants provided by this class, or a
+     * custom regex without the '#' character (used as delimiter).
+     *
+     * @return string The filtered attribute name.
+     */
+    public static function filterAttrName($name, $allow = self::EXTENDED_ALPHANUMERIC)
+    {
+        return preg_replace('#'.$allow.'#', '', $name);
     }
 }

--- a/src/Utils/XPath.php
+++ b/src/Utils/XPath.php
@@ -4,10 +4,10 @@ namespace RobRichards\XMLSecLibs\Utils;
 
 class XPath
 {
-    const ALPHANUMERIC = '[^\w\d]';
-    const NUMERIC = '[^\d]';
-    const LETTERS = '[^\w]';
-    const EXTENDED_ALPHANUMERIC = '[^\w\d\s-_:\.]';
+    const ALPHANUMERIC = '\w\d';
+    const NUMERIC = '\d';
+    const LETTERS = '\w';
+    const EXTENDED_ALPHANUMERIC = '\w\d\s-_:\.';
 
     const SINGLE_QUOTE = '\'';
     const DOUBLE_QUOTE = '"';
@@ -33,12 +33,12 @@ class XPath
      *
      * @param string $name The attribute name to filter.
      * @param mixed $allow The set of characters to allow. Can be one of the constants provided by this class, or a
-     * custom regex without the '#' character (used as delimiter).
+     * custom regex excluding the '#' character (used as delimiter).
      *
      * @return string The filtered attribute name.
      */
     public static function filterAttrName($name, $allow = self::EXTENDED_ALPHANUMERIC)
     {
-        return preg_replace('#'.$allow.'#', '', $name);
+        return preg_replace('#[^'.$allow.']#', '', $name);
     }
 }

--- a/src/XMLSecEnc.php
+++ b/src/XMLSecEnc.php
@@ -5,6 +5,7 @@ use DOMDocument;
 use DOMNode;
 use DOMXPath;
 use Exception;
+use RobRichards\XMLSecLibs\Utils\XPath as XPath;
 
 /**
  * xmlseclibs.php
@@ -470,7 +471,7 @@ class XMLSecEnc
                     }
                     $id = substr($uri, 1);
 
-                    $query = "//xmlsecenc:EncryptedKey[@Id='$id']";
+                    $query = "//xmlsecenc:EncryptedKey[@Id='".XPath::filter($id)."']";
                     $keyElement = $xpath->query($query)->item(0);
                     if (!$keyElement) {
                         throw new Exception("Unable to locate EncryptedKey with @Id='$id'.");

--- a/src/XMLSecEnc.php
+++ b/src/XMLSecEnc.php
@@ -471,7 +471,7 @@ class XMLSecEnc
                     }
                     $id = substr($uri, 1);
 
-                    $query = "//xmlsecenc:EncryptedKey[@Id='".XPath::filter($id)."']";
+                    $query = '//xmlsecenc:EncryptedKey[@Id="'.XPath::filterAttrValue($id, XPAth::DOUBLE_QUOTE).'"]';
                     $keyElement = $xpath->query($query)->item(0);
                     if (!$keyElement) {
                         throw new Exception("Unable to locate EncryptedKey with @Id='$id'.");

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -493,7 +493,8 @@ class XMLSecurityDSig
                     $iDlist = '@Id="'.XPath::filter($identifier).'"';
                     if (is_array($this->idKeys)) {
                         foreach ($this->idKeys AS $idKey) {
-                            $iDlist .= " or @$idKey='".XPATH::filter($idKey)."'";
+                            $iDlist .= " or @".XPath::filter($idKey)."='".XPATH::filter($identifier).
+                                "'";
                         }
                     }
                     $query = '//*['.$iDlist.']';

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -490,11 +490,11 @@ class XMLSecurityDSig
                             $xPath->registerNamespace($nspf, $ns);
                         }
                     }
-                    $iDlist = '@Id="'.XPath::filter($identifier).'"';
+                    $iDlist = '@Id="'.XPath::filterAttrValue($identifier, XPath::DOUBLE_QUOTE).'"';
                     if (is_array($this->idKeys)) {
                         foreach ($this->idKeys AS $idKey) {
-                            $iDlist .= " or @".XPath::filter($idKey)."='".XPATH::filter($identifier).
-                                "'";
+                            $iDlist .= " or @".XPath::filterAttrName($idKey).'="'.
+                                XPATH::filterAttrValue($identifier, XPAth::DOUBLE_QUOTE).'"';
                         }
                     }
                     $query = '//*['.$iDlist.']';

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -6,6 +6,7 @@ use DOMElement;
 use DOMNode;
 use DOMXPath;
 use Exception;
+use RobRichards\XMLSecLibs\Utils\XPath as XPath;
 
 /**
  * xmlseclibs.php
@@ -489,10 +490,10 @@ class XMLSecurityDSig
                             $xPath->registerNamespace($nspf, $ns);
                         }
                     }
-                    $iDlist = '@Id="'.$identifier.'"';
+                    $iDlist = '@Id="'.XPath::filter($identifier).'"';
                     if (is_array($this->idKeys)) {
                         foreach ($this->idKeys AS $idKey) {
-                            $iDlist .= " or @$idKey='$identifier'";
+                            $iDlist .= " or @$idKey='".XPATH::filter($idKey)."'";
                         }
                     }
                     $query = '//*['.$iDlist.']';

--- a/xmlseclibs.php
+++ b/xmlseclibs.php
@@ -44,3 +44,4 @@ $xmlseclibs_srcdir = dirname(__FILE__) . '/src/';
 require $xmlseclibs_srcdir . '/XMLSecurityKey.php';
 require $xmlseclibs_srcdir . '/XMLSecurityDSig.php';
 require $xmlseclibs_srcdir . '/XMLSecEnc.php';
+require $xmlseclibs_srcdir . '/Utils/XPath.php';


### PR DESCRIPTION
In order to avoid XPath injection, user input must be filtered before it ends up in the query. Unfortunately, there's no way to do this with a standard method in PHP, so we need our own filtering function. Current best practice recommends using white lists instead of black lists to allow only a subset of characters. In this case, we allow only letters, numericals, spaces, dashes and underscores.

This fixes a bug also inside a loop, where `$identifier` is used instead of `$idKey` (the element in the current loop iteration).