### PR TITLE
Add fixes for travis-ci issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
         - EXECUTE_COVERAGE=true
     - php: 7
     - php: 7.1
+    - php: 7.2
   allow_failures:
     - php: hhvm
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     - php: 5.6
       env:
         - EXECUTE_COVERAGE=true
-    - php: 7
+    - php: 7.0.27
     - php: 7.1
     - php: 7.2
   allow_failures:


### PR DESCRIPTION
As described in https://github.com/travis-ci/travis-ci/issues/8211 php 7 in travis-ci is configured with a non-working version of PHPUnit and should be replaced with PHP 7.0.21 until there is a new distribution for PHP 7.
With the stable release of PHP 7.2 I also added this to the travis.yml.