### PR TITLE
Document potentially dangerous return value behaviour.

### DIFF
--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -585,6 +585,16 @@ class XMLSecurityKey
 
     /**
      * Verifies the data (string) against the given signature using the extension assigned to the type in the constructor.
+     *
+     * Returns in case of openSSL:
+     *  1 on succesful signature verification,
+     *  0 when signature verification failed,
+     *  -1 if an error occurred during processing.
+     *
+     * NOTE: be very careful when checking the return value, because in PHP,
+     * -1 will be cast to True when in boolean context. So always check the
+     * return value in a strictly typed way, e.g. "$obj->verify(...) === 1".
+     *
      * @param string $data
      * @param string $signature
      * @return bool|int


### PR DESCRIPTION
This function may pass the return value of verifyOpenSSL() which is easily misinterpreted.

This comment has been added to the docs of verifyOpenSSL() but may go unnoticed when using this function that wraps it.