### PR TITLE
Include InclusiveNamespaces specified in CanonicalizationMethod when canonicalizing SignedInfo

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -300,6 +300,7 @@ class XMLSecurityDSig
         $doc = $this->sigNode->ownerDocument;
         $canonicalmethod = null;
         if ($doc) {
+            $prefixList = [];
             $xpath = $this->getXPathObj();
             $query = "./secdsig:SignedInfo";
             $nodeset = $xpath->query($query, $this->sigNode);
@@ -308,8 +309,28 @@ class XMLSecurityDSig
                 $nodeset = $xpath->query($query, $signInfoNode);
                 if ($canonNode = $nodeset->item(0)) {
                     $canonicalmethod = $canonNode->getAttribute('Algorithm');
+                    $node = $canonNode->firstChild;
+                    while ($node) {
+                        if ($node->localName == 'InclusiveNamespaces') {
+                            if ($pfx = $node->getAttribute('PrefixList')) {
+                                $arpfx = array();
+                                $pfxlist = explode(" ", $pfx);
+                                foreach ($pfxlist AS $pfx) {
+                                    $val = trim($pfx);
+                                    if (! empty($val)) {
+                                        $arpfx[] = $val;
+                                    }
+                                }
+                                if (count($arpfx) > 0) {
+                                    $prefixList = $arpfx;
+                                }
+                            }
+                            break;
+                        }
+                        $node = $node->nextSibling;
+                    }
                 }
-                $this->signedInfo = $this->canonicalizeData($signInfoNode, $canonicalmethod);
+                $this->signedInfo = $this->canonicalizeData($signInfoNode, $canonicalmethod, null, $prefixList);
                 return $this->signedInfo;
             }
         }


### PR DESCRIPTION
The current implementation ignores inclusive namespaces when canonicalizing the SignedInfo element. This pull request ensures that an InclusiveNamespaces element within the topmost CanonicalizationMethod element is also parsed and included in the SignedInfo canonicalization, preventing signature verification issues when the canonicalized XML would differ as a result.

This may fix #98, but I'm not 100% sure of that.