### PR TITLE
make regex PCRE2 compliant

### DIFF
--- a/src/Utils/XPath.php
+++ b/src/Utils/XPath.php
@@ -7,7 +7,7 @@ class XPath
     const ALPHANUMERIC = '\w\d';
     const NUMERIC = '\d';
     const LETTERS = '\w';
-    const EXTENDED_ALPHANUMERIC = '\w\d\s-_:\.';
+    const EXTENDED_ALPHANUMERIC = '\w\d\s\-_:\.';
 
     const SINGLE_QUOTE = '\'';
     const DOUBLE_QUOTE = '"';


### PR DESCRIPTION
PHP7.3 makes a hard switch from PCRE to PCRE2, where the hyphen needs to be escaped. I've tested and confirmed that with PHP 7.3rc3
- the code as was before this PR breaks with a PHP error about unable to compile the regex
- the code with this one-character PR applied works just fine