### PR TITLE
test for PHP 7.3 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - php: 7.0.27
     - php: 7.1
     - php: 7.2
+    - php: 7.3
   allow_failures:
     - php: hhvm
     


### PR DESCRIPTION
recent builds of Travis already have a target PHP 7.3. To learn early about things like the PCRE -> PCRE2 breakages, PHP 7.3 should be tested from now on