### PR TITLE
Fix: preg_replace(): Compilation failed: invalid range in character class at offset 8

### DIFF
--- a/src/Utils/XPath.php
+++ b/src/Utils/XPath.php
@@ -7,7 +7,7 @@ class XPath
     const ALPHANUMERIC = '\w\d';
     const NUMERIC = '\d';
     const LETTERS = '\w';
-    const EXTENDED_ALPHANUMERIC = '\w\d\s\-_:\.';
+    const EXTENDED_ALPHANUMERIC = '-\w\d\s\_:\.';
 
     const SINGLE_QUOTE = '\'';
     const DOUBLE_QUOTE = '"';


### PR DESCRIPTION
Wrong regular expression causing following warning

	Warning: preg_replace(): Compilation failed: invalid range in character class at offset 8 in ...vendor/robrichards/xmlseclibs/src/Utils/XPath.php on line 42