### PR TITLE
Add RSA MGF1 signature types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ matrix:
   fast_finish: true
   include:
     - php: 5.4
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
       env:
         - EXECUTE_COVERAGE=true
@@ -16,10 +18,10 @@ matrix:
     - php: 7.3
   allow_failures:
     - php: hhvm
-    
+
 script:
   - if [[ $EXECUTE_COVERAGE == 'true' ]]; then phpunit --coverage-clover clover.xml tests; fi
   - if [[ $EXECUTE_COVERAGE != 'true' ]]; then phpunit tests; fi
-  
+
 after_success:
   - if [[ $EXECUTE_COVERAGE == 'true' ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,20 @@ matrix:
     - php: hhvm
 
 script:
-  - if [[ $LOCAL_PHPUNIT == 'false' ]]; then composer require --dev phpunit/phpunit; phpunitbin=./vendor/bin/phpunit; fi
-  - if [[ $LOCAL_PHPUNIT != 'false' ]]; then phpunitbin=phpunit; fi
-  - if [[ $EXECUTE_COVERAGE == 'true' ]]; then $phpunitbin --coverage-clover clover.xml tests; fi
-  - if [[ $EXECUTE_COVERAGE != 'true' ]]; then $phpunitbin tests; fi
+  - |
+    if [[ $LOCAL_PHPUNIT == 'false' ]]; then
+      composer require --dev phpunit/phpunit
+      export phpunitbin="./vendor/bin/phpunit"
+    else
+      export phpunitbin="phpunit"
+      fi
+  - |
+    if [[ $EXECUTE_COVERAGE == 'true' ]]; then
+      export phpunitparms="--coverage-clover clover.xml tests"
+    else
+      export phpunitparms="tests"
+      fi
+  - echo $phpunitbin $phpunitparms && $phpunitbin $phpunitparms
 
 after_success:
   - if [[ $EXECUTE_COVERAGE == 'true' ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,25 @@ matrix:
       env:
         - EXECUTE_COVERAGE=true
     - php: 7.0.27
+      env:
+        - LOCAL_PHPUNIT=false
     - php: 7.1
+      env:
+        - LOCAL_PHPUNIT=false
     - php: 7.2
     - php: 7.3
   allow_failures:
     - php: hhvm
 
 script:
-  - if [[ $EXECUTE_COVERAGE == 'true' ]]; then phpunit --coverage-clover clover.xml tests; fi
-  - if [[ $EXECUTE_COVERAGE != 'true' ]]; then phpunit tests; fi
+  - if [[ $LOCAL_PHPUNIT == 'false' ]]; then composer require --dev phpunit/phpunit; phpunitbin=./vendor/bin/phpunit; fi
+  - if [[ $LOCAL_PHPUNIT != 'false' ]]; then phpunitbin=phpunit; fi
+  - if [[ $EXECUTE_COVERAGE == 'true' ]]; then $phpunitbin --coverage-clover clover.xml tests; fi
+  - if [[ $EXECUTE_COVERAGE != 'true' ]]; then $phpunitbin tests; fi
 
 after_success:
   - if [[ $EXECUTE_COVERAGE == 'true' ]]; then bash <(curl -s https://codecov.io/bash); fi
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files

--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -57,6 +57,10 @@ class XMLSecurityKey
     const RSA_SHA256 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
     const RSA_SHA384 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384';
     const RSA_SHA512 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512';
+    const SHA1_RSA_MGF1 = 'http://www.w3.org/2007/05/xmldsig-more#sha1-rsa-MGF1';
+    const SHA256_RSA_MGF1 = 'http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1';
+    const SHA384_RSA_MGF1 = 'http://www.w3.org/2007/05/xmldsig-more#sha384-rsa-MGF1';
+    const SHA512_RSA_MGF1 = 'http://www.w3.org/2007/05/xmldsig-more#sha512-rsa-MGF1';
     const HMAC_SHA1 = 'http://www.w3.org/2000/09/xmldsig#hmac-sha1';
 
     /** @var array */
@@ -212,6 +216,54 @@ class XMLSecurityKey
                     }
                 }
                 throw new Exception('Certificate "type" (private/public) must be passed via parameters');
+            case (self::SHA1_RSA_MGF1):
+                $this->cryptParams['library'] = 'openssl';
+                $this->cryptParams['padding'] = OPENSSL_PKCS1_OAEP_PADDING;
+                $this->cryptParams['method'] = 'http://www.w3.org/2007/05/xmldsig-more#sha1-rsa-MGF1';
+                $this->cryptParams['digest'] = 'SHA1';
+                if (is_array($params) && ! empty($params['type'])) {
+                  if ($params['type'] == 'public' || $params['type'] == 'private') {
+                    $this->cryptParams['type'] = $params['type'];
+                    break;
+                  }
+                }
+                throw new Exception('Certificate "type" (private/public) must be passed via parameters');
+            case (self::SHA256_RSA_MGF1):
+                $this->cryptParams['library'] = 'openssl';
+                $this->cryptParams['padding'] = OPENSSL_PKCS1_OAEP_PADDING;
+                $this->cryptParams['method'] = 'http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1';
+                $this->cryptParams['digest'] = 'SHA256';
+                if (is_array($params) && ! empty($params['type'])) {
+                  if ($params['type'] == 'public' || $params['type'] == 'private') {
+                    $this->cryptParams['type'] = $params['type'];
+                    break;
+                  }
+                }
+                throw new Exception('Certificate "type" (private/public) must be passed via parameters');
+            case (self::SHA384_RSA_MGF1):
+                $this->cryptParams['library'] = 'openssl';
+                $this->cryptParams['padding'] = OPENSSL_PKCS1_OAEP_PADDING;
+                $this->cryptParams['method'] = 'http://www.w3.org/2007/05/xmldsig-more#sha384-rsa-MGF1';
+                $this->cryptParams['digest'] = 'SHA384';
+                if (is_array($params) && ! empty($params['type'])) {
+                  if ($params['type'] == 'public' || $params['type'] == 'private') {
+                    $this->cryptParams['type'] = $params['type'];
+                    break;
+                  }
+                }
+                throw new Exception('Certificate "type" (private/public) must be passed via parameters');
+            case (self::SHA512_RSA_MGF1):
+                $this->cryptParams['library'] = 'openssl';
+                $this->cryptParams['padding'] = OPENSSL_PKCS1_OAEP_PADDING;
+                $this->cryptParams['method'] = 'http://www.w3.org/2007/05/xmldsig-more#sha512-rsa-MGF1';
+                $this->cryptParams['digest'] = 'SHA512';
+                if (is_array($params) && ! empty($params['type'])) {
+                  if ($params['type'] == 'public' || $params['type'] == 'private') {
+                    $this->cryptParams['type'] = $params['type'];
+                    break;
+                  }
+                }
+                throw new Exception('Certificate "type" (private/public) must be passed via parameters');
             case (self::HMAC_SHA1):
                 $this->cryptParams['library'] = $type;
                 $this->cryptParams['method'] = 'http://www.w3.org/2000/09/xmldsig#hmac-sha1';
@@ -250,9 +302,9 @@ class XMLSecurityKey
             throw new Exception('Unknown key size for type "' . $this->type . '".');
         }
         $keysize = $this->cryptParams['keysize'];
-        
+
         $key = openssl_random_pseudo_bytes($keysize);
-        
+
         if ($this->type === self::TRIPLEDES_CBC) {
             /* Make sure that the generated key has the proper parity bits set.
              * Mcrypt doesn't care about the parity bits, but others may care.
@@ -267,7 +319,7 @@ class XMLSecurityKey
                 $key[$i] = chr($byte);
             }
         }
-        
+
         $this->key = $key;
         return $key;
     }


### PR DESCRIPTION
I have no idea what I am doing! Someone with crypto expertise please check my work! :smile: 

It seems OAEP and MGF1 refer to the same (or are simply included) underlying functions, so simply extending the XMLSecurityKey class with the new definitions in [RFC6931#Section-2.3.10](https://tools.ietf.org/html/rfc6931#section-2.3.10) does the job, but maybe it's not that simple.

Tested to correctly verify against sample in #199, unable to test generation, so no units included either.