### PR TITLE
FIX missing InclusiveNamespaces PrefixList from Java + Apache WSS4J

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -324,7 +324,7 @@ class XMLSecurityDSig
                                 $arpfx = array_filter(explode(' ', $pfx));
                                 if (count($arpfx) > 0) {
                                     $prefixList = array_merge($prefixList ? $prefixList : array(), $arpfx);
-                				}
+                                }
                             }
                         }
                     }

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -314,10 +314,22 @@ class XMLSecurityDSig
             if ($signInfoNode = $nodeset->item(0)) {
                 $query = "./secdsig:CanonicalizationMethod";
                 $nodeset = $xpath->query($query, $signInfoNode);
+                $prefixList = null;
                 if ($canonNode = $nodeset->item(0)) {
                     $canonicalmethod = $canonNode->getAttribute('Algorithm');
+                    foreach ($canonNode->childNodes as $node)
+                    {
+                        if ($node->localName == 'InclusiveNamespaces') {
+                            if ($pfx = $node->getAttribute('PrefixList')) {
+                                $arpfx = array_filter(explode(' ', $pfx));
+                                if (count($arpfx) > 0) {
+                                    $prefixList = array_merge($prefixList ? $prefixList : array(), $arpfx);
+                				}
+                            }
+                        }
+                    }
                 }
-                $this->signedInfo = $this->canonicalizeData($signInfoNode, $canonicalmethod);
+                $this->signedInfo = $this->canonicalizeData($signInfoNode, $canonicalmethod, null, $prefixList);
                 return $this->signedInfo;
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/robrichards/wse-php/issues/37

example: parse php array('cor', 'mod', 'soapenv') for canonicalizeData function call from xml below

<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
<ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="cor mod soapenv"/>
</ds:CanonicalizationMethod>