### PR TITLE
Fix keysize of aes128-gcm and aes192-gcm

### DIFF
--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -151,7 +151,7 @@ class XMLSecurityKey
                 $this->cryptParams['cipher'] = 'aes-128-gcm';
                 $this->cryptParams['type'] = 'symmetric';
                 $this->cryptParams['method'] = 'http://www.w3.org/2009/xmlenc11#aes128-gcm';
-                $this->cryptParams['keysize'] = 32;
+                $this->cryptParams['keysize'] = 16;
                 $this->cryptParams['blocksize'] = 16;
                 break;
             case (self::AES192_GCM):
@@ -159,7 +159,7 @@ class XMLSecurityKey
                 $this->cryptParams['cipher'] = 'aes-192-gcm';
                 $this->cryptParams['type'] = 'symmetric';
                 $this->cryptParams['method'] = 'http://www.w3.org/2009/xmlenc11#aes192-gcm';
-                $this->cryptParams['keysize'] = 32;
+                $this->cryptParams['keysize'] = 24;
                 $this->cryptParams['blocksize'] = 16;
                 break;
             case (self::AES256_GCM):


### PR DESCRIPTION
I came across this using SimpleSAMLphp 1.18.7 and release 3.1.0 of your library against and Shibboleth IdP 4 using aes-128-gcm. Setting the correct keysize fixed the problem.

Thanks for the really great library.