### PR TITLE
Included InclusiveNamespaces PrefixList for Reference/Signature and Fixed setAttributeNS Problem

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -835,12 +835,12 @@ class XMLSecurityDSig
     public function sign($objKey, $appendToNode = null)
     {
         // If we have a parent node append it now so C14N properly works
+        $this->sigNode = $this->rebuildNode($this->sigNode);
         if ($appendToNode != null) {
             $this->resetXPathObj();
             $this->appendSignature($appendToNode);
             $this->sigNode = $appendToNode->lastChild;
         }
-        $this->sigNode = $this->rebuildNode($this->sigNode);
         if ($xpath = $this->getXPathObj()) {
             $query = "./secdsig:SignedInfo";
             $nodeset = $xpath->query($query, $this->sigNode);

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -628,7 +628,7 @@ class XMLSecurityDSig
             $id_name = empty($options['id_name']) ? 'Id' : $options['id_name'];
             $overwrite_id = !isset($options['overwrite']) ? true : (bool) $options['overwrite'];
             $force_uri = !isset($options['force_uri']) ? false : (bool) $options['force_uri'];
-            $include_ns = !isset($options['include_ns:'.$node->localName]) ? false : $options['include_ns'];
+            $include_ns = !isset($options['include_ns:'.$node->localName]) ? false : $options['include_ns'.$node->localName];
         }
 
         $attname = $id_name;

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -222,6 +222,7 @@ class XMLSecurityDSig
 
     /**
      * @param string $method
+     * @param string|array $include_ns
      * @throws Exception
      */
     public function setCanonicalMethod($method, $include_ns=false)
@@ -396,6 +397,8 @@ class XMLSecurityDSig
     }
 
     /**
+     * Transforms the $objData according to the Algorithm and Inclusive Namespaces defined on the $refNode into it's Canonicalized form.
+     * 
      * @param $refNode
      * @param DOMNode $objData
      * @param bool $includeCommentNodes
@@ -717,6 +720,8 @@ class XMLSecurityDSig
     }
 
     /**
+     * Adds Reference Nodes for all $arNodes to the SignedInfo Node.
+     * 
      * @param array $arNodes
      * @param string $algorithm
      * @param null|array $arTransforms

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -246,7 +246,7 @@ class XMLSecurityDSig
                 if (! ($canonNode = $nodeset->item(0))) {
                     $canonNode = $this->createNewSignNode('CanonicalizationMethod');
                     $sinfo->insertBefore($canonNode, $sinfo->firstChild);
-                    if($include_ns != false && ($method == self::EXC_C14N || $method == self::EXC_C14N_COMMENTS)) {
+                    if($include_ns !== false && ($method == self::EXC_C14N || $method == self::EXC_C14N_COMMENTS)) {
                         $includeNode = $this->sigNode->ownerDocument->createElementNS($method, 'ec:InclusiveNamespaces', null);
                         $includeNode->setAttribute('PrefixList', is_array($include_ns) ? implode(' ', $include_ns) : $include_ns);
                         $canonNode->appendChild($includeNode);
@@ -628,7 +628,7 @@ class XMLSecurityDSig
             $id_name = empty($options['id_name']) ? 'Id' : $options['id_name'];
             $overwrite_id = !isset($options['overwrite']) ? true : (bool) $options['overwrite'];
             $force_uri = !isset($options['force_uri']) ? false : (bool) $options['force_uri'];
-            $include_ns = !isset($options['include_ns:'.$node->localName]) ? false : $options['include_ns'.$node->localName];
+            $include_ns = !isset($options['include_ns:'.$node->localName]) ? false : $options['include_ns:'.$node->localName];
         }
 
         $attname = $id_name;
@@ -684,7 +684,7 @@ class XMLSecurityDSig
             $transNodes->appendChild($transNode);
             $transNode->setAttribute('Algorithm', $this->canonicalMethod);
             
-            if($include_ns != false && ($this->canonicalMethod == self::EXC_C14N || $this->canonicalMethod == self::EXC_C14N_COMMENTS)) {
+            if($include_ns !== false && ($this->canonicalMethod == self::EXC_C14N || $this->canonicalMethod == self::EXC_C14N_COMMENTS)) {
                 $includeNode = $this->sigNode->ownerDocument->createElementNS($this->canonicalMethod, 'ec:InclusiveNamespaces');
                 $includeNode->setAttribute('PrefixList', is_array($include_ns) ? implode(' ', $include_ns) : $include_ns);
                 $transNode->appendChild($includeNode);

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -633,7 +633,7 @@ class XMLSecurityDSig
             }
             if (empty($uri)) {
                 $uri = self::generateGUID();
-                $attrib = $this->sigNode->ownerDocument->createAttributeNS($prefix_ns, $attname);
+                $attrib = $node->ownerDocument->createAttributeNS($prefix_ns, $attname);
                 $attrib->value = $uri;
                 $node->setAttributeNodeNS($attrib);
             }
@@ -840,6 +840,7 @@ class XMLSecurityDSig
             $this->appendSignature($appendToNode);
             $this->sigNode = $appendToNode->lastChild;
         }
+        $this->sigNode = $this->rebuildNode($this->sigNode);
         if ($xpath = $this->getXPathObj()) {
             $query = "./secdsig:SignedInfo";
             $nodeset = $xpath->query($query, $this->sigNode);
@@ -883,6 +884,29 @@ class XMLSecurityDSig
             }
         }
         return null;
+    }
+    
+    
+    /**
+     * Rebuild the inserted $node to include all Namespaces down from the SubTree to the Root!
+     * This Action should be envoked if there is a new Element with a differing Namespace appended to another Element that has already been appended to the Refering $node and a Canonicalization is needed!
+     *
+     *
+     * @param DOMElement $node
+     * @return null|DOMElement
+     */
+    private function rebuildNode($node) {
+        if(isset($node) && $node->hasChildNodes()) {
+            $childNodes = array();
+            foreach($node->childNodes as $child) {
+                $childNodes[] = $child;
+            }
+            foreach($childNodes as $child) {
+                $node->removeChild($child);
+                $node->appendChild($this->rebuildNode($child));
+            }
+        }
+        return $node;
     }
     
 

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -628,7 +628,7 @@ class XMLSecurityDSig
             $id_name = empty($options['id_name']) ? 'Id' : $options['id_name'];
             $overwrite_id = !isset($options['overwrite']) ? true : (bool) $options['overwrite'];
             $force_uri = !isset($options['force_uri']) ? false : (bool) $options['force_uri'];
-            $include_ns = !isset($options['include_ns']) ? false : $options['include_ns'];
+            $include_ns = !isset($options['include_ns:'.$node->localName]) ? false : $options['include_ns'];
         }
 
         $attname = $id_name;
@@ -726,6 +726,12 @@ class XMLSecurityDSig
      * @param string $algorithm
      * @param null|array $arTransforms
      * @param null|array $options
+     *      Takes Arguments:    prefix      => string ;
+     *                          prefix_ns   => string ;
+     *                          id_name     => string ;
+     *                          overwrite   => boolean ;
+     *                          force_uri   => boolean ;
+     *                          include_ns  => string | array
      */
     public function addReferenceList($arNodes, $algorithm, $arTransforms=null, $options=null)
     {

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -731,7 +731,7 @@ class XMLSecurityDSig
      *                          id_name     => string ;
      *                          overwrite   => boolean ;
      *                          force_uri   => boolean ;
-     *                          include_ns  => string | array
+     *                          include_ns:[localName of Node]  => string | array
      */
     public function addReferenceList($arNodes, $algorithm, $arTransforms=null, $options=null)
     {


### PR DESCRIPTION
The current implementation doesn't support the construction and processing of InclusiveNamespaces for Transforming/Canonicalizing. This pull request includes the possibility to pre-set specific Namespaces for referenced-/signedinfo-elements during the Canonicaliztion-Process and compressed the processing of that info on a private Method.

Another Problem occuring was, that the DOMNode->setAttributeNS() is not registering the Namespace URI properly, so that it doesn't react as expected on the C14N call if it's namespace-prefix is in the prefixList!
This Problem is avoidable if the Attribute is first created on the Document and then applied to the Node! That way the namespace gets registered properly.

This might solve [#211](https://github.com/robrichards/xmlseclibs/issues/211)

Edit: _There is a Problem with the correct Canonicalization of the SignedInfo if you try to use Include Namespaces not held by the Template but by the Document to be signed!_ (I oversaw, that one should already be solved in the sign Method!)
Another Problem occurs if you append a new Element with a differing Namespace to an already appended Element! The Namespaces are not properly registered on the Parent Nodes. A possible workaround is to reconstruct the Node-Tree! Otherwise the Canonicalization doesn't seem to always work properly.