### PR TITLE
Enc, DSig: Add public preserveWhiteSpace and formatOutput switches

### DIFF
--- a/src/XMLSecEnc.php
+++ b/src/XMLSecEnc.php
@@ -76,6 +76,12 @@ class XMLSecEnc
     /** @var array */
     private $references = array();
 
+    /** @var bool */
+    public $preserveWhiteSpace = true;
+
+    /** @var bool */
+    public $formatOutput = false;
+
     public function __construct()
     {
         $this->_resetTemplate();
@@ -84,6 +90,8 @@ class XMLSecEnc
     private function _resetTemplate()
     {
         $this->encdoc = new DOMDocument();
+        $this->encdoc->preserveWhiteSpace = $this->preserveWhiteSpace;
+        $this->encdoc->formatOutput = $this->formatOutput;
         $this->encdoc->loadXML(self::template);
     }
 

--- a/src/XMLSecEnc.php
+++ b/src/XMLSecEnc.php
@@ -77,13 +77,15 @@ class XMLSecEnc
     private $references = array();
 
     /** @var bool */
-    public $preserveWhiteSpace = true;
+    private $preserveWhiteSpace = true;
 
     /** @var bool */
-    public $formatOutput = false;
+    private $formatOutput = false;
 
-    public function __construct()
+    public function __construct($preserveWhiteSpace=true, $formatOutput=false)
     {
+        $this->preserveWhiteSpace = $preserveWhiteSpace;
+        $this->formatOutput = $formatOutput;
         $this->_resetTemplate();
     }
 

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -104,6 +104,12 @@ class XMLSecurityDSig
      */
     private $validatedNodes = null;
 
+    /** @var bool */
+    public $preserveWhiteSpace = true;
+
+    /** @var bool */
+    public $formatOutput = false;
+
     /**
      * @param string $prefix
      */
@@ -117,6 +123,8 @@ class XMLSecurityDSig
             $template = str_replace($search, $replace, $template);
         }
         $sigdoc = new DOMDocument();
+        $sigdoc->preserveWhiteSpace = $this->preserveWhiteSpace;
+        $sigdoc->formatOutput = $this->formatOutput;
         $sigdoc->loadXML($template);
         $this->sigNode = $sigdoc->documentElement;
     }

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -104,16 +104,10 @@ class XMLSecurityDSig
      */
     private $validatedNodes = null;
 
-    /** @var bool */
-    public $preserveWhiteSpace = true;
-
-    /** @var bool */
-    public $formatOutput = false;
-
     /**
      * @param string $prefix
      */
-    public function __construct($prefix='ds')
+    public function __construct($prefix='ds', $preserveWhiteSpace=true, $formatOutput=false)
     {
         $template = self::BASE_TEMPLATE;
         if (! empty($prefix)) {
@@ -123,8 +117,8 @@ class XMLSecurityDSig
             $template = str_replace($search, $replace, $template);
         }
         $sigdoc = new DOMDocument();
-        $sigdoc->preserveWhiteSpace = $this->preserveWhiteSpace;
-        $sigdoc->formatOutput = $this->formatOutput;
+        $sigdoc->preserveWhiteSpace = $preserveWhiteSpace;
+        $sigdoc->formatOutput = $formatOutput;
         $sigdoc->loadXML($template);
         $this->sigNode = $sigdoc->documentElement;
     }


### PR DESCRIPTION
This is somehow related to following issues and pull requests:
* https://github.com/robrichards/xmlseclibs/issues/77 - Signature value Issue
* https://github.com/robrichards/xmlseclibs/pull/143 - Add option to use template excluding whitespace
* SimpleSAMLphp: https://github.com/simplesamlphp/simplesamlphp-module-adfs/pull/7 - Compact resulting XML

I propose to enable ability to skip whitespaces and formatting from the XML Enc and Sig templates using the generic options from DOMDocument class: preserveWhiteSpace and formatOutput, and make it configurable with options with the same names. Current behavior is set as default one.

Some relying parties may be highly sensitive to redundant spaces, tabs and newlines in the XML payload while they can (and should) be considered as true XML text nodes. It appears in e.g. WSFed module in .NET Core 3.1 and .NET 5.

Enabling solution like this to the upstream brings no risk to existing relying solutions.
