### PR TITLE
Never modify original document

### DIFF
--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -591,24 +591,27 @@ class XMLSecurityDSig
      */
     public function validateReference()
     {
-        $docElem = $this->sigNode->ownerDocument->documentElement;
-        if (! $docElem->isSameNode($this->sigNode)) {
-            if ($this->sigNode->parentNode != null) {
-                $this->sigNode->parentNode->removeChild($this->sigNode);
+        $sigNode = $this->sigNode;
+        $docElem = $sigNode->ownerDocument->documentElement;
+
+        // enveloped signature, remove it
+        if (!$docElem->isSameNode($sigNode)) {
+            if ($sigNode->parentNode !== null) {
+                $sigNode->parentNode->removeChild($sigNode);
             }
         }
         $xpath = $this->getXPathObj();
         $query = "./secdsig:SignedInfo[1]/secdsig:Reference";
-        $nodeset = $xpath->query($query, $this->sigNode);
-        if ($nodeset->length == 0) {
+        $nodeset = $xpath->query($query, $sigNode);
+        if ($nodeset->length < 1) {
             throw new Exception("Reference nodes not found");
         }
 
         /* Initialize/reset the list of validated nodes. */
-        $this->validatedNodes = array();
+        $this->validatedNodes = [];
 
-        foreach ($nodeset AS $refNode) {
-            if (! $this->processRefNode($refNode)) {
+        foreach ($nodeset as $refNode) {
+            if (!$this->processRefNode($refNode)) {
                 /* Clear the list of validated nodes. */
                 $this->validatedNodes = null;
                 throw new Exception("Reference validation failed");


### PR DESCRIPTION
HI @robrichards !

I noticed that this method manipulates the original document that holds the sigNode and removes the entire signature from the bigger XML document..  This PR should fix it!