### PR TITLE
Make whitespace in created signature node configurable option because of C# DOTNET signature validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
+# guycalledseven xmlseclib fork
+
+This fork has one small but **very important** change in `XMLSecurityDSig` class. order to make signatures verifiable on C#. 
+
+Adding of signatures is done via predefined template string constant which contains whitespaces. If signed xml should not contain whitespaces - this will break signature and it won't validate (on eg. c#).
+
+To fix this, constructor now accepts optional parameters `$preserveWhiteSpace` and `$formatOutput` which now default both to false.
+
+
+```
+    /**
+     * Added preserveWhiteSpace = false since validating signature in C# fails because 
+     * signature base template contains & inserts whitespaces on it's own
+     * @param string $prefix
+     * @param boolean $preserveWhiteSpace
+     * @param boolean $formatOutput
+     */
+    public function __construct($prefix='ds', $preserveWhiteSpace = false, $formatOutput = false)
+    {
+
+    	...
+
+        $sigdoc = new DOMDocument();
+		$sigdoc->preserveWhiteSpace = $preserveWhiteSpace;
+		$sigdoc->formatOutput = $formatOutput;
+
+        $sigdoc->loadXML($template);
+        $this->sigNode = $sigdoc->documentElement;
+    }
+	
+
+```
+
 #xmlseclibs 
 
 xmlseclibs is a library written in PHP for working with XML Encryption and Signatures.

--- a/src/XMLSecurityDSig.php
+++ b/src/XMLSecurityDSig.php
@@ -105,9 +105,13 @@ class XMLSecurityDSig
     private $validatedNodes = null;
 
     /**
+     * Added preserveWhiteSpace = false since validating signature in C# fails because 
+     * signature base template contains & inserts whitespaces on it's own
      * @param string $prefix
+     * @param boolean $preserveWhiteSpace
+     * @param boolean $formatOutput
      */
-    public function __construct($prefix='ds')
+    public function __construct($prefix='ds', $preserveWhiteSpace = false, $formatOutput = false)
     {
         $template = self::BASE_TEMPLATE;
         if (! empty($prefix)) {
@@ -117,6 +121,9 @@ class XMLSecurityDSig
             $template = str_replace($search, $replace, $template);
         }
         $sigdoc = new DOMDocument();
+		$sigdoc->preserveWhiteSpace = $preserveWhiteSpace;
+		$sigdoc->formatOutput = $formatOutput;
+
         $sigdoc->loadXML($template);
         $this->sigNode = $sigdoc->documentElement;
     }


### PR DESCRIPTION
I've created my fork after many hours spent on debugging.

I've extended constructor with new default properties:

```
public function __construct($prefix='ds', $preserveWhiteSpace = false, $formatOutput = false)
```

I am not quite happy with implementation because it does not follow general whitespace configuration of `DOMDocument` object eg. this would be more straight forward to read:

```
$objDSig = new XMLSecurityDSig('');
$objDSig->preserveWhiteSpace = false;
$objDSig->formatOutput = false;
```

This is unfortunately not possible since `XMLSecurityDSig` object transforms signature template via `DOMDocument` to xml in it's constructor.

This is related to:
1. https://github.com/robrichards/xmlseclibs/issues/247
2. https://github.com/robrichards/xmlseclibs/issues/77
3. https://github.com/robrichards/xmlseclibs/pull/221

Looking forward to change PR if necessary to better incorporate it in `xmlseclibs` package.