### PR TITLE
loadKey should check return value for openssl_get_privatekey

### DIFF
--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -384,6 +384,9 @@ class XMLSecurityKey
 
 	            case 'private':
                     $this->key = openssl_get_privatekey($this->key, $this->passphrase);
+                    if ($this->key === false) {
+                        throw new Exception('Unable to extract private key (invalid key or passphrase): ' . openssl_error_string());
+                    }
                     break;
 
                 case'symmetric':


### PR DESCRIPTION
The function openssl_get_privatekey may return false, for example if the passphrase is incorrect. In the other 2 branches of the switch statement, this is checked and an exception thrown, but it was not checked in the private key branch. This commit adds a check.

This makes it easier to detect problems with invalid keys or pass phrases. Without this change, you are likely to get a confusing exception later on when it tries to use the key.