### PR TITLE
ci: Use GitHub Actions V3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           extensions: openssl
           tools: phpunit:4.8
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
           extensions: openssl
           tools: phpunit:6.5
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -72,7 +72,7 @@ jobs:
           extensions: openssl
           tools: phpunit:8.5
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -99,7 +99,7 @@ jobs:
           extensions: openssl
           tools: phpunit/phpunit:9.5
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
This PR updates the GitHub Actions from V2 to V3.

All annotated warning link to the official GitHub documentation: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/