### PR TITLE
Added support for RSASSA_PSS (sha256-rsa-MGF1)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
   },
   "require": {
     "php": ">= 5.4",
-    "ext-openssl": "*"
+    "ext-openssl": "*",
+    "phpseclib/phpseclib": "^3.0"
   }
 }

--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -371,6 +371,9 @@ class XMLSecurityKey
 
             if ($this->cryptParams['library'] == self::RSASSA_PSS) {
                 $this->rsaPrivateKey = PublicKeyLoader::loadPrivateKey(file_get_contents($key));
+                $this->rsaPrivateKey->withPadding(RSA::SIGNATURE_PSS);
+                $this->rsaPrivateKey->withHash('sha256');
+                $this->rsaPrivateKey->withMGFHash('sha256');
             }
         } else {
             $this->key = $key;
@@ -659,11 +662,7 @@ class XMLSecurityKey
             case (self::HMAC_SHA1):
                 return hash_hmac("sha1", $data, $this->key, true);
             case (self::RSASSA_PSS):
-                $privateKey = $this->rsaPrivateKey;
-                $privateKey->withPadding(RSA::SIGNATURE_PSS);
-                $privateKey->withHash('sha256');
-                $privateKey->withMGFHash('sha256');
-                return $privateKey->sign($data);
+                return $this->rsaPrivateKey->sign($data);
         }
     }
 
@@ -691,6 +690,8 @@ class XMLSecurityKey
             case (self::HMAC_SHA1):
                 $expectedSignature = hash_hmac("sha1", $data, $this->key, true);
                 return strcmp($signature, $expectedSignature) == 0;
+            case (self::RSASSA_PSS):
+                return $this->rsaPrivateKey->verify($data, $signature);
         }
     }
 

--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -388,19 +388,22 @@ class XMLSecurityKey
         }
         if ($this->cryptParams['library'] == 'openssl') {
             switch ($this->cryptParams['type']) {
-                case 'public':
-                    if ($isCert) {
-                        /* Load the thumbprint if this is an X509 certificate. */
-                        $this->X509Thumbprint = self::getRawThumbprint($this->key);
-                    }
-                    $this->key = openssl_get_publickey($this->key);
-                    if (! $this->key) {
-                        throw new Exception('Unable to extract public key');
-                    }
-                    break;
+	            case 'public':
+	                if ($isCert) {
+	                    /* Load the thumbprint if this is an X509 certificate. */
+	                    $this->X509Thumbprint = self::getRawThumbprint($this->key);
+	                }
+	                $this->key = openssl_get_publickey($this->key);
+	                if (! $this->key) {
+	                    throw new Exception('Unable to extract public key');
+	                }
+	                break;
 
-                case 'private':
+	            case 'private':
                     $this->key = openssl_get_privatekey($this->key, $this->passphrase);
+                    if ($this->key === false) {
+                        throw new Exception('Unable to extract private key (invalid key or passphrase): ' . openssl_error_string());
+                    }
                     break;
 
                 case'symmetric':

--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -1,7 +1,6 @@
 <?php
 namespace RobRichards\XMLSecLibs;
 
-use Alzura\Domain\Fiscal\BzSt;
 use DOMElement;
 use Exception;
 use phpseclib3\Crypt\PublicKeyLoader;

--- a/src/XMLSecurityKey.php
+++ b/src/XMLSecurityKey.php
@@ -388,7 +388,7 @@ class XMLSecurityKey
         }
         if ($this->cryptParams['library'] == 'openssl') {
             switch ($this->cryptParams['type']) {
-	            case 'public':
+                case 'public':
 	                if ($isCert) {
 	                    /* Load the thumbprint if this is an X509 certificate. */
 	                    $this->X509Thumbprint = self::getRawThumbprint($this->key);


### PR DESCRIPTION
In my project I needed to sign with the http://www.w3.org/2007/05/xmldsig-more#sha256-rsa-MGF1 algorithm.

To support this, I added phpseclib/phpseclib which has the possibility to create RSA keys in this format.