### PR TITLE
Upgrade GitHub Actions off deprecated Node runtimes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit/phpunit:9.6
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
       - name: Run tests
         run: phpunit --coverage-clover clover.xml tests
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./clover.xml
@@ -47,7 +47,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit/phpunit:9.6
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -57,7 +57,7 @@ jobs:
       - name: Run tests
         run: phpunit --coverage-clover clover.xml tests
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./clover.xml
@@ -76,7 +76,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           tools: phpunit/phpunit:9.6
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -86,7 +86,7 @@ jobs:
       - name: Run tests
         run: phpunit --coverage-clover clover.xml tests
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./clover.xml


### PR DESCRIPTION
actions/checkout@v3 (node16) and codecov-action@v2 (node12) trigger Node 20 deprecation warnings; bump both to Node 24-compatible majors.