### PR TITLE
Add optional whitespace-stripped EncryptedData template

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -71,6 +71,9 @@ Features:
 - Add optional $options constructor argument on XMLSecurityDSig; pass
   'stripWhitespace' => true (default false) to build signatures from a
   compact template with no whitespace between elements (BASE_TEMPLATE_NOWS)
+- Add optional $options constructor argument on XMLSecEnc; pass
+  'stripWhitespace' => true (default false) to build EncryptedData from a
+  compact template with no whitespace between elements (template_NOWS)
 
 Notes:
 - Prefer RSA-OAEP and AES-GCM for new deployments; RSA-1.5 and CBC remain
@@ -87,6 +90,9 @@ Bug Fixes:
 - Compact signature template (XMLSecurityDSig 'stripWhitespace' option) removes
   inter-element whitespace that caused signature mismatch with C# SignedXml and
   Python signxml.
+- Compact encryption template (XMLSecEnc 'stripWhitespace' option) removes
+  inter-element whitespace from EncryptedData for peers that reject significant
+  whitespace between elements.
 
 12, Dec 2025, 3.1.5
 Security:

--- a/src/XMLSecEnc.php
+++ b/src/XMLSecEnc.php
@@ -56,6 +56,8 @@ class XMLSecEnc
    </xenc:CipherData>
 </xenc:EncryptedData>";
 
+    const template_NOWS = "<xenc:EncryptedData xmlns:xenc='http://www.w3.org/2001/04/xmlenc#'><xenc:CipherData><xenc:CipherValue></xenc:CipherValue></xenc:CipherData></xenc:EncryptedData>";
+
     const Element = 'http://www.w3.org/2001/04/xmlenc#Element';
     const Content = 'http://www.w3.org/2001/04/xmlenc#Content';
     const URI = 3;
@@ -130,8 +132,19 @@ class XMLSecEnc
     /** @var array */
     private $references = array();
 
-    public function __construct()
+    /** @var string */
+    private $activeTemplate;
+
+    /**
+     * @param null|array $options Optional flags; use 'stripWhitespace' => true for a compact template
+     */
+    public function __construct($options=null)
     {
+        $stripWhitespace = false;
+        if (is_array($options)) {
+            $stripWhitespace = !isset($options['stripWhitespace']) ? false : (bool) $options['stripWhitespace'];
+        }
+        $this->activeTemplate = $stripWhitespace ? self::template_NOWS : self::template;
         $this->_resetTemplate();
     }
 
@@ -157,7 +170,7 @@ class XMLSecEnc
     private function _resetTemplate()
     {
         $this->encdoc = new DOMDocument();
-        $this->encdoc->loadXML(self::template);
+        $this->encdoc->loadXML($this->activeTemplate);
     }
 
     /**


### PR DESCRIPTION
Allow XMLSecEnc constructors to use a compact template_NOWS via options['stripWhitespace'] (default false) without changing existing output.